### PR TITLE
Update phonesettings.module

### DIFF
--- a/ari/modules/phonesettings.module
+++ b/ari/modules/phonesettings.module
@@ -206,7 +206,7 @@ class phonesettings {
 
 
                 $m = "phonesettings";
-                $ret = "<form class='phonesettings' name='ari_settings' action='' method='GET'>
+                $ret = "<form class='phonesettings' name='ari_settings' action='' method='POST'>
                         <input type=hidden name=m value=" . $m . ">
                         <input type=hidden name=f value='action'>
                         <input type=hidden name=a value='update'>


### PR DESCRIPTION
The statement method='GET' works when you do not have a lot of data to be updated. When we are using our remote phonebook setting with our Yealink V70 package with 120+ fields entered and customizable, we the GET method fails due to the URL being displayed too long. When we use the POST method, there are no errors.
