### PR TITLE
Disable continuous mode for coda slider

### DIFF
--- a/templates/freepbx/template_editor.html
+++ b/templates/freepbx/template_editor.html
@@ -10,7 +10,8 @@
         <script type="text/javascript">
             $().ready(function() {
                 $('#coda-slider-9').codaSlider({
-                    dynamicArrows: false
+                    dynamicArrows: false,
+                    continuous: false
                 });
             });
         </script>
@@ -22,7 +23,8 @@
 <script language="javascript" type="text/javascript">
     $().ready(function() {
         $('#coda-slider-9').codaSlider({
-            dynamicArrows: false
+            dynamicArrows: false,
+            continuous: false
         });
     });
     function Reload() {


### PR DESCRIPTION
Disabling continuous mode prevents the first (and last) property pages in the template from being duplicated, which allows users to submit entries successfully. See: <http://issues.freepbx.org/browse/FC-88>