### PR TITLE
Made server IP configurable for HTTP provisioning

### DIFF
--- a/includes/functions.inc
+++ b/includes/functions.inc
@@ -1480,7 +1480,7 @@ class endpointmanager {
                 if (!$write) {
                     $new_template_data['provision']['type'] = 'dynamic';
                     $new_template_data['provision']['protocol'] = 'http';
-                    $new_template_data['provision']['path'] = $_SERVER["SERVER_ADDR"] . dirname($_SERVER['REQUEST_URI']) . '/';
+                    $new_template_data['provision']['path'] = rtrim($settings['srvip'] . dirname($_SERVER['REQUEST_URI']) . '/', '/');
                     $new_template_data['provision']['encryption'] = FALSE;
                 } else {
                     $new_template_data['provision']['type'] = 'file';


### PR DESCRIPTION
My Asterisk server runs on Amazon AWS and by default, the `SERVER_ADDR` is the internal IP address assigned by the VPC's DHCP server.  That's obviously not accessible publicly which is a problem, so this uses the IP/hostname configured by an admin instead.