### PR TITLE
Fixes an issue generating provisioning XML for Cisco SPA phones

### DIFF
--- a/Endpointman.class.php
+++ b/Endpointman.class.php
@@ -1006,7 +1006,7 @@ $this->error['get_phone_info'] = "Mac ID is not set";
 
     	//$res = sql($sql);
 		$res = sql($sql, 'getAll', DB_FETCHMODE_ASSOC);
-    	if ($res->numRows()) {
+    	if ($res->rowCount()) {
     		//Returns Brand Name, Brand Directory, Model Name, Mac Address, Extension (FreePBX), Custom Configuration Template, Custom Configuration Data, Product Name, Product ID, Product Configuration Directory, Product Configuration Version, Product XML name,
     		$sql = "SELECT endpointman_mac_list.specific_settings, endpointman_mac_list.config_files_override, endpointman_mac_list.global_user_cfg_data, endpointman_model_list.id as model_id, endpointman_brand_list.id as brand_id, endpointman_brand_list.name, endpointman_brand_list.directory, endpointman_model_list.model, endpointman_mac_list.mac, endpointman_mac_list.template_id, endpointman_mac_list.global_custom_cfg_data, endpointman_product_list.long_name, endpointman_product_list.id as product_id, endpointman_product_list.cfg_dir, endpointman_product_list.cfg_ver, endpointman_model_list.template_data, endpointman_model_list.enabled, endpointman_mac_list.global_settings_override FROM endpointman_line_list, endpointman_mac_list, endpointman_model_list, endpointman_brand_list, endpointman_product_list WHERE endpointman_mac_list.model = endpointman_model_list.id AND endpointman_brand_list.id = endpointman_model_list.brand AND endpointman_product_list.id = endpointman_model_list.product_id AND endpointman_mac_list.id = endpointman_line_list.mac_id AND endpointman_mac_list.id = " . $mac_id;
     		$phone_info = sql($sql, 'getRow', DB_FETCHMODE_ASSOC);
@@ -1074,7 +1074,7 @@ $this->error['get_phone_info'] = "Error with SQL Statement";
     	$brand = sql($oui_sql, 'getRow', DB_FETCHMODE_ASSOC);
 
     	$res = sql($oui_sql);
-    	$brand_count = $res->numRows();
+    	$brand_count = $res->rowCount();
 
     	if (!$brand_count) {
     		//oui doesn't have a matching mysql reference, probably a PC/router/wap/printer of some sort.
@@ -1163,9 +1163,9 @@ $this->error['get_phone_info'] = "Error with SQL Statement";
 
     			//Timezone
     			try {
-    				$provisioner_lib->DateTimeZone = new DateTimeZone($settings['tz']);
+    				$provisioner_lib->DateTimeZone = new \DateTimeZone($settings['tz']);
     			} catch (Exception $e) {
-$this->error['parse_configs'] = 'Error Returned From Timezone Library: ' . $e->getMessage();
+						$this->error['parse_configs'] = 'Error Returned From Timezone Library: ' . $e->getMessage();
     				return(FALSE);
     			}
 
@@ -1181,7 +1181,7 @@ $this->error['parse_configs'] = 'Error Returned From Timezone Library: ' . $e->g
     						$sql = "SELECT original_name,data FROM endpointman_custom_configs WHERE id = " . $list;
     						//$res = sql($sql);
 							$res = sql($sql, 'getAll', DB_FETCHMODE_ASSOC);
-    						if ($res->numRows()) {
+    						if ($res->rowCount()) {
     							$data = sql($sql, 'getRow', DB_FETCHMODE_ASSOC);
     							$provisioner_lib->config_files_override[$data['original_name']] = $data['data'];
     						}
@@ -1196,7 +1196,7 @@ $this->error['parse_configs'] = 'Error Returned From Timezone Library: ' . $e->g
     						$sql = "SELECT original_name,data FROM endpointman_custom_configs WHERE id = " . $list;
     						//$res = sql($sql);
 							$res = sql($sql, 'getAll', DB_FETCHMODE_ASSOC);
-    						if ($res->numRows()) {
+    						if ($res->rowCount()) {
     							$data = sql($sql, 'getRow', DB_FETCHMODE_ASSOC);
     							$provisioner_lib->config_files_override[$data['original_name']] = $data['data'];
     						}
@@ -1745,7 +1745,7 @@ $this->error['parse_configs'] = "File not written to hard drive!";
                 $brand = $this->eda->sql($oui_sql, 'getRow', DB_FETCHMODE_ASSOC);
 
                 $res = $this->eda->sql($oui_sql);
-                $brand_count = $res->numRows();
+                $brand_count = $res->rowCount();
 
                 if (!$brand_count) {
                     //oui doesn't have a matching mysql reference, probably a PC/router/wap/printer of some sort.
@@ -1759,7 +1759,7 @@ $this->error['parse_configs'] = "File not written to hard drive!";
 
                 $res = $this->eda->sql($epm_sql);
 
-                $epm = $res->numRows() ? TRUE : FALSE;
+                $epm = $res->rowCount() ? TRUE : FALSE;
 
                 //Add into a final array
                 $final[$z] = array("ip" => $ip, "mac" => $mac, "mac_strip" => $mac_strip, "oui" => $oui, "brand" => $brand['name'], "brand_id" => $brand['id'], "endpoint_managed" => $epm);

--- a/Endpointman.class.php
+++ b/Endpointman.class.php
@@ -1282,7 +1282,7 @@ $this->error['get_phone_info'] = "Error with SQL Statement";
     			$li = 0;
     			foreach ($phone_info['line'] as $line) {
     				$line_options = is_array($line_ops[$line['line']]) ? $line_ops[$line['line']] : array();
-    				$line_statics = array('line' => $line['line'], 'username' => $line['ext'], 'authname' => $line['ext'], 'secret' => $line['secret'], 'displayname' => $line['description'], 'server_host' => $this->global_cfg['srvip'], 'server_port' => '5060', 'user_extension' => $line['user_extension']);
+    				$line_statics = array('line' => $line['line'], 'username' => $line['ext'], 'authname' => $line['ext'], 'secret' => $line['secret'], 'displayname' => $line['description'], 'server_host' => $settings['srvip'], 'server_port' => '5060', 'user_extension' => $line['user_extension']);
 
     				$provisioner_lib->settings['line'][$li] = array_merge($line_options, $line_statics);
     				$li++;

--- a/provisioning/p.php
+++ b/provisioning/p.php
@@ -65,13 +65,13 @@ if(getMethod() == "GET") {
     $filename = basename($_SERVER["REQUEST_URI"]);
     $web_path = 'http://'.$_SERVER["SERVER_NAME"].dirname($_SERVER["PHP_SELF"]).'/';
     /*
-    if ($filename == "p.php") { 
+    if ($filename == "p.php") {
             $filename = "spa502G.cfg";
             $_SERVER['REQUEST_URI']=$_SERVER['REQUEST_URI']."/spa502G.cfg";
             $web_path = $web_path."p.php/";
     }
      */
-    
+
     # Firmware Linksys/SPA504G-7.4.3a is broken and MUST be upgraded.
     if (preg_match('/7.4.3a/', $_SERVER['HTTP_USER_AGENT'])) {
             $str = '<flat-profile><Upgrade_Enable group="Provisioning/Firmware_Upgrade">Yes</Upgrade_Enable>';
@@ -79,27 +79,25 @@ if(getMethod() == "GET") {
             echo $str;
             exit;
     }
-	
+
     $filename = str_replace('p.php/','', $filename);
     $strip = str_replace('spa', '', $filename);
-    
+
     if(preg_match('/[0-9A-Fa-f]{12}/i', $strip, $matches) && !(preg_match('/[0]{10}[0-9]{2}/i',$strip))) {
-    	echo "a";
-    	exit;
         $mac_address = $matches[0];
-        
+
         $sql = "SELECT id FROM `endpointman_mac_list` WHERE `mac` LIKE '%" . $mac_address . "%'";
         $mac_id = sql($sql, 'getOne');
         $phone_info = FreePBX::Endpointman()->get_phone_info($mac_id);
-		$files = FreePBX::Endpointman()->prepare_configs($phone_info, FALSE, FALSE);
-        
+				$files = FreePBX::Endpointman()->prepare_configs($phone_info, FALSE, FALSE);
+
         if(!$files) {
             header("HTTP/1.0 500 Internal Server Error", true, 500);
             echo "<h1>"._("Error 500 Internal Server Error")."</h1>";
             echo _("System Failure!");
             die();
         }
-        
+
         if (array_key_exists($filename, $files)) {
             echo $files[$filename];
         } else {
@@ -109,13 +107,13 @@ if(getMethod() == "GET") {
             die();
         }
 
-    } 
+    }
     else {
         require_once (PROVISIONER_BASE.'endpoint/base.php');
         $data = Provisioner_Globals::dynamic_global_files($filename, FreePBX::Endpointman()->configmod->get("config_location"), $web_path);
         if($data !== FALSE) {
             echo $data;
-        } 
+        }
         else {
         	header("HTTP/1.0 404 Not Found", true, 404);
         	echo "<h1>"._("Error 404 Not Found")."</h1>";
@@ -123,7 +121,7 @@ if(getMethod() == "GET") {
         	die();
         }
     }
-} 
+}
 else {
     header('HTTP/1.1 403 Forbidden', true, 403);
     echo "<h1>"._("Error 403 Forbidden")."</h1>";


### PR DESCRIPTION
This fixes 3 issues:

- Removes the exit statement that prevented the XML file for SPA phones to be generated.
- `numRows()` isn’t a method of `PDOStatement` so replaces those calls with `rowCount()`.
- `DateTimeZone` needed to come from the global namespace and not the current one.