### PR TITLE
pjsip_support: Add support for extensions using res_pjsip driver

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -62,19 +62,18 @@ function endpointman_configpageinit($pagename) {
 		if(!$tech) {
 			$tech = "sip";
 			$type = 'new';
-		} elseif($tech == 'sip') {
+		} elseif($tech == 'sip' OR $tech == 'pjsip') {
 			$type = 'edit';
-			$tech = 'sip';
 		}
     } elseif(isset($_REQUEST['tech_hardware']) OR isset($_REQUEST['tech'])) {
 		$tech = isset($_REQUEST['tech_hardware']) ? $_REQUEST['tech_hardware'] : $_REQUEST['tech'];
-		if(($tech == 'sip_generic') OR ($tech == 'sip')) {
+		if(($tech == 'sip_generic') OR ($tech == 'sip') OR ($tech == 'pjsip')) {
         	$tech = "sip";
 			$type = 'new';
 		}
     }
 
-    if (($tech == 'sip') AND (!empty($type))) {
+    if ((($tech == 'sip') OR ($tech == 'pjsip')) AND (!empty($type))) {
         global $endpoint;
 
 	    $action = isset($_REQUEST['action']) ? $_REQUEST['action'] : null;
@@ -209,7 +208,7 @@ function endpointman_configpageload() {
         $tech = isset($_REQUEST['tech_hardware']) ? $_REQUEST['tech_hardware'] : null;
     }
 
-    if (isset($tech) && (($tech == 'sip') OR ($tech == 'sip_generic'))) {
+    if (isset($tech) && (($tech == 'sip') OR ($tech == 'pjsip') OR ($tech == 'sip_generic'))) {
         // Don't display this stuff it it's on a 'This xtn has been deleted' page.
         if ($action != 'del') {
 

--- a/includes/devices_manager.inc
+++ b/includes/devices_manager.inc
@@ -219,7 +219,7 @@ switch ($sub_type) {
                     $provisioner_lib->brand_name = $phone_info['directory'];
                     $provisioner_lib->family_line = $phone_info['cfg_dir'];
 
-                    $provisioner_lib->settings['line'][0] = array('username' => $phone_info['line'][1]['ext'], 'authname' => $phone_info['line'][1]['ext']);
+                    $provisioner_lib->settings['line'][0] = array('username' => $phone_info['line'][1]['ext'], 'authname' => $phone_info['line'][1]['ext'], 'tech' => $phone_info['line'][1]['tech']);
                     $provisioner_lib->reboot();
                     unset($provisioner_lib);
                 }
@@ -372,6 +372,22 @@ foreach($device_statuses as $key => $data) {
     preg_match('/\b(?:\d{1,3}\.){3}\d{1,3}\b/i', $data, $ipaddress);
     if(!empty($extout[1])) {
         if(preg_match('/OK \(.*\)/i', $data)) {
+           $devices_status[$extout[1]]['status'] = TRUE;
+           $devices_status[$extout[1]]['ip'] = $ipaddress[0];
+        } else {
+            $devices_status[$extout[1]]['status'] = FALSE;
+        }
+    }
+}
+
+// Do the same for the pjsip peers
+$device_statuses = shell_exec($endpoint->global_cfg['asterisk_location']." -rx 'pjsip show contacts'");
+$device_statuses = explode("\n", $device_statuses);
+foreach($device_statuses as $key => $data) {
+    preg_match('/Contact:\s+(\d+)\/sip:.*/i', $data, $extout);
+    preg_match('/\b(?:\d{1,3}\.){3}\d{1,3}\b/i', $data, $ipaddress);
+    if(!empty($extout[1])) {
+        if(preg_match('/Avail\s+\d+/i', $data)) {
            $devices_status[$extout[1]]['status'] = TRUE;
            $devices_status[$extout[1]]['ip'] = $ipaddress[0];
         } else {

--- a/includes/functions.inc
+++ b/includes/functions.inc
@@ -1526,7 +1526,7 @@ class endpointmanager {
                 $li = 0;
                 foreach ($phone_info['line'] as $line) {
                     $line_options = is_array($line_ops[$line['line']]) ? $line_ops[$line['line']] : array();
-                    $line_statics = array('line' => $line['line'], 'username' => $line['ext'], 'authname' => $line['ext'], 'secret' => $line['secret'], 'displayname' => $line['description'], 'server_host' => $this->global_cfg['srvip'], 'server_port' => '5060', 'user_extension' => $line['user_extension']);
+                    $line_statics = array('line' => $line['line'], 'username' => $line['ext'], 'authname' => $line['ext'], 'secret' => $line['secret'], 'displayname' => $line['description'], 'server_host' => $this->global_cfg['srvip'], 'server_port' => '5060', 'user_extension' => $line['user_extension'], 'tech' => $line['tech']);
 
                     $provisioner_lib->settings['line'][$li] = array_merge($line_options, $line_statics);
                     $li++;


### PR DESCRIPTION
Add support for extensions where tech=“pjsip”.  This includes presenting the provisioner tab for
extensions of type pjsip and detection of current status.

Also adds the ‘tech’ attribute to all calls to provisioner reboot() functions to allow tailoring
of behaviour where required (e.g. different process for sending SIP notifications).