### PR TITLE
php71 fixes

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -282,7 +282,7 @@ function endpointman_configpageload() {
                 $currentcomponent->addguielem($section, new gui_checkbox('epm_delete', $checked, 'Delete', 'Delete this Extension from Endpoint Manager'), 9);
 // phone web interface link
 	class gui_link_nw_tab extends guitext {
-    function gui_link_nw_tab($elemname, $text, $url, $userlang = true) {
+    function __construct($elemname, $text, $url, $userlang = true) {
         $parent_class = get_parent_class($this);
         $this->html_text = "<a href=\"$url\" target=\"_blank\" id =\"$this->elemname\">$text</a>";
     }

--- a/includes/pear_diff/Diff.php
+++ b/includes/pear_diff/Diff.php
@@ -35,7 +35,7 @@ class Text_Diff {
      *                           Normally an array of two arrays, each
      *                           containing the lines from a file.
      */
-    function Text_Diff($engine, $params)
+    function __construct($engine, $params)
     {
         // Backward compatibility workaround.
         if (!is_string($engine)) {
@@ -49,8 +49,11 @@ class Text_Diff {
             $engine = basename($engine);
         }
 
-        require_once 'Text/Diff/Engine/' . $engine . '.php';
         $class = 'Text_Diff_Engine_' . $engine;
+        if (!class_exists($class)) {
+            require_once 'Text/Diff/Engine/' . $engine . '.php';
+        }
+
         $diff_engine = new $class();
 
         $this->_edits = call_user_func_array(array($diff_engine, 'diff'), $params);
@@ -63,7 +66,7 @@ class Text_Diff {
     {
         return $this->_edits;
     }
-    
+
     /**
      * returns the number of new (added) lines in a given diff.
      *
@@ -83,7 +86,7 @@ class Text_Diff {
         }
         return $count;
     }
-    
+
     /**
      * Returns the number of deleted (removed) lines in a given diff.
      *
@@ -208,7 +211,7 @@ class Text_Diff {
      * @param string $line  The line to trim.
      * @param integer $key  The index of the line in the array. Not used.
      */
-    function trimNewlines(&$line, $key)
+    static function trimNewlines(&$line, $key)
     {
         $line = str_replace(array("\n", "\r"), '', $line);
     }
@@ -216,14 +219,12 @@ class Text_Diff {
     /**
      * Determines the location of the system temporary directory.
      *
-     * @static
-     *
      * @access protected
      *
      * @return string  A directory name which can be used for temp files.
      *                 Returns false if one could not be found.
      */
-    function _getTempDir()
+    static function _getTempDir()
     {
         $tmp_locations = array('/tmp', '/var/tmp', 'c:\WUTemp', 'c:\temp',
                                'c:\windows\temp', 'c:\winnt\temp');
@@ -307,13 +308,13 @@ class Text_MappedDiff extends Text_Diff {
      * @param array $mapped_to_lines    This array should have the same number
      *                                  of elements as $to_lines.
      */
-    function Text_MappedDiff($from_lines, $to_lines,
+    function __construct($from_lines, $to_lines,
                              $mapped_from_lines, $mapped_to_lines)
     {
         assert(count($from_lines) == count($mapped_from_lines));
         assert(count($to_lines) == count($mapped_to_lines));
 
-        parent::Text_Diff($mapped_from_lines, $mapped_to_lines);
+        parent::__construct($mapped_from_lines, $mapped_to_lines);
 
         $xi = $yi = 0;
         for ($i = 0; $i < count($this->_edits); $i++) {
@@ -369,7 +370,7 @@ class Text_Diff_Op {
  */
 class Text_Diff_Op_copy extends Text_Diff_Op {
 
-    function Text_Diff_Op_copy($orig, $final = false)
+    function __construct($orig, $final = false)
     {
         if (!is_array($final)) {
             $final = $orig;
@@ -380,7 +381,7 @@ class Text_Diff_Op_copy extends Text_Diff_Op {
 
     function &reverse()
     {
-        $reverse = &new Text_Diff_Op_copy($this->final, $this->orig);
+        $reverse = new Text_Diff_Op_copy($this->final, $this->orig);
         return $reverse;
     }
 
@@ -394,7 +395,7 @@ class Text_Diff_Op_copy extends Text_Diff_Op {
  */
 class Text_Diff_Op_delete extends Text_Diff_Op {
 
-    function Text_Diff_Op_delete($lines)
+    function __construct($lines)
     {
         $this->orig = $lines;
         $this->final = false;
@@ -402,7 +403,7 @@ class Text_Diff_Op_delete extends Text_Diff_Op {
 
     function &reverse()
     {
-        $reverse = &new Text_Diff_Op_add($this->orig);
+        $reverse = new Text_Diff_Op_add($this->orig);
         return $reverse;
     }
 
@@ -416,7 +417,7 @@ class Text_Diff_Op_delete extends Text_Diff_Op {
  */
 class Text_Diff_Op_add extends Text_Diff_Op {
 
-    function Text_Diff_Op_add($lines)
+    function __construct($lines)
     {
         $this->final = $lines;
         $this->orig = false;
@@ -424,7 +425,7 @@ class Text_Diff_Op_add extends Text_Diff_Op {
 
     function &reverse()
     {
-        $reverse = &new Text_Diff_Op_delete($this->final);
+        $reverse = new Text_Diff_Op_delete($this->final);
         return $reverse;
     }
 
@@ -438,7 +439,7 @@ class Text_Diff_Op_add extends Text_Diff_Op {
  */
 class Text_Diff_Op_change extends Text_Diff_Op {
 
-    function Text_Diff_Op_change($orig, $final)
+    function __construct($orig, $final)
     {
         $this->orig = $orig;
         $this->final = $final;
@@ -446,7 +447,7 @@ class Text_Diff_Op_change extends Text_Diff_Op {
 
     function &reverse()
     {
-        $reverse = &new Text_Diff_Op_change($this->final, $this->orig);
+        $reverse = new Text_Diff_Op_change($this->final, $this->orig);
         return $reverse;
     }
 

--- a/includes/pear_diff/Diff/Engine/native.php
+++ b/includes/pear_diff/Diff/Engine/native.php
@@ -106,7 +106,7 @@ class Text_Diff_Engine_native {
                 ++$yi;
             }
             if ($copy) {
-                $edits[] = &new Text_Diff_Op_copy($copy);
+                $edits[] = new Text_Diff_Op_copy($copy);
             }
 
             // Find deletes & adds.
@@ -121,11 +121,11 @@ class Text_Diff_Engine_native {
             }
 
             if ($delete && $add) {
-                $edits[] = &new Text_Diff_Op_change($delete, $add);
+                $edits[] = new Text_Diff_Op_change($delete, $add);
             } elseif ($delete) {
-                $edits[] = &new Text_Diff_Op_delete($delete);
+                $edits[] = new Text_Diff_Op_delete($delete);
             } elseif ($add) {
-                $edits[] = &new Text_Diff_Op_add($add);
+                $edits[] = new Text_Diff_Op_add($add);
             }
         }
 

--- a/includes/pear_diff/Diff/Engine/xdiff.php
+++ b/includes/pear_diff/Diff/Engine/xdiff.php
@@ -47,15 +47,15 @@ class Text_Diff_Engine_xdiff {
             }
             switch ($line[0]) {
             case ' ':
-                $edits[] = &new Text_Diff_Op_copy(array(substr($line, 1)));
+                $edits[] = new Text_Diff_Op_copy(array(substr($line, 1)));
                 break;
 
             case '+':
-                $edits[] = &new Text_Diff_Op_add(array(substr($line, 1)));
+                $edits[] = new Text_Diff_Op_add(array(substr($line, 1)));
                 break;
 
             case '-':
-                $edits[] = &new Text_Diff_Op_delete(array(substr($line, 1)));
+                $edits[] = new Text_Diff_Op_delete(array(substr($line, 1)));
                 break;
             }
         }

--- a/includes/pear_diff/Diff/Mapped.php
+++ b/includes/pear_diff/Diff/Mapped.php
@@ -28,13 +28,13 @@ class Text_Diff_Mapped extends Text_Diff {
      * @param array $mapped_to_lines    This array should have the same number
      *                                  of elements as $to_lines.
      */
-    function Text_Diff_Mapped($from_lines, $to_lines,
+    function __construct($from_lines, $to_lines,
                               $mapped_from_lines, $mapped_to_lines)
     {
         assert(count($from_lines) == count($mapped_from_lines));
         assert(count($to_lines) == count($mapped_to_lines));
 
-        parent::Text_Diff($mapped_from_lines, $mapped_to_lines);
+        parent::__construct($mapped_from_lines, $mapped_to_lines);
 
         $xi = $yi = 0;
         for ($i = 0; $i < count($this->_edits); $i++) {

--- a/includes/pear_diff/Diff/Renderer.php
+++ b/includes/pear_diff/Diff/Renderer.php
@@ -35,7 +35,7 @@ class Text_Diff_Renderer {
     /**
      * Constructor.
      */
-    function Text_Diff_Renderer($params = array())
+    function __construct($params = array())
     {
         foreach ($params as $param => $value) {
             $v = '_' . $param;

--- a/includes/pear_diff/Diff/Renderer/context.php
+++ b/includes/pear_diff/Diff/Renderer/context.php
@@ -15,7 +15,9 @@
  */
 
 /** Text_Diff_Renderer */
-require_once 'Text/Diff/Renderer.php';
+if (!class_exists('Text_Diff_Renderer')) {
+    require_once 'Text/Diff/Renderer.php';
+}
 
 /**
  * @package Text_Diff

--- a/includes/pear_diff/Diff/Renderer/inline.php
+++ b/includes/pear_diff/Diff/Renderer/inline.php
@@ -14,7 +14,9 @@
  */
 
 /** Text_Diff_Renderer */
-require_once 'Text/Diff/Renderer.php';
+if (!class_exists('Text_Diff_Renderer')) {
+    require_once 'Text/Diff/Renderer.php';
+}
 
 /**
  * "Inline" diff renderer.

--- a/includes/pear_diff/Diff/Renderer/unified.php
+++ b/includes/pear_diff/Diff/Renderer/unified.php
@@ -16,7 +16,9 @@
  */
 
 /** Text_Diff_Renderer */
-require_once 'Text/Diff/Renderer.php';
+if (!class_exists('Text_Diff_Renderer')) {
+    require_once 'Text/Diff/Renderer.php';
+}
 
 /**
  * @package Text_Diff

--- a/includes/pear_diff/Diff/ThreeWay.php
+++ b/includes/pear_diff/Diff/ThreeWay.php
@@ -14,7 +14,9 @@
  */
 
 /** Text_Diff */
-require_once 'Text/Diff.php';
+if (!class_exists('Text_Diff')) {
+    require_once 'Text/Diff.php';
+}
 
 /**
  * A class for computing three way diffs.
@@ -38,7 +40,7 @@ class Text_Diff_ThreeWay extends Text_Diff {
      * @param array $final1  The first version to compare to.
      * @param array $final2  The second version to compare to.
      */
-    function Text_Diff_ThreeWay($orig, $final1, $final2)
+    function __construct($orig, $final1, $final2)
     {
         if (extension_loaded('xdiff')) {
             $engine = new Text_Diff_Engine_xdiff();
@@ -155,7 +157,7 @@ class Text_Diff_ThreeWay extends Text_Diff {
  */
 class Text_Diff_ThreeWay_Op {
 
-    function Text_Diff_ThreeWay_Op($orig = false, $final1 = false, $final2 = false)
+    function __construct($orig = false, $final1 = false, $final2 = false)
     {
         $this->orig = $orig ? $orig : array();
         $this->final1 = $final1 ? $final1 : array();
@@ -194,7 +196,7 @@ class Text_Diff_ThreeWay_Op {
  */
 class Text_Diff_ThreeWay_Op_copy extends Text_Diff_ThreeWay_Op {
 
-    function Text_Diff_ThreeWay_Op_Copy($lines = false)
+    function __construct($lines = false)
     {
         $this->orig = $lines ? $lines : array();
         $this->final1 = &$this->orig;
@@ -221,7 +223,7 @@ class Text_Diff_ThreeWay_Op_copy extends Text_Diff_ThreeWay_Op {
  */
 class Text_Diff_ThreeWay_BlockBuilder {
 
-    function Text_Diff_ThreeWay_BlockBuilder()
+    function __construct()
     {
         $this->_init();
     }

--- a/includes/pear_diff/Diff3.php
+++ b/includes/pear_diff/Diff3.php
@@ -14,7 +14,9 @@
  */
 
 /** Text_Diff */
-require_once 'Text/Diff.php';
+if (!class_exists('Text_Diff')) {
+    require_once 'Text/Diff.php';
+}
 
 /**
  * A class for computing three way diffs.
@@ -38,7 +40,7 @@ class Text_Diff3 extends Text_Diff {
      * @param array $final1  The first version to compare to.
      * @param array $final2  The second version to compare to.
      */
-    function Text_Diff3($orig, $final1, $final2)
+    function __construct($orig, $final1, $final2)
     {
         if (extension_loaded('xdiff')) {
             $engine = new Text_Diff_Engine_xdiff();
@@ -155,7 +157,7 @@ class Text_Diff3 extends Text_Diff {
  */
 class Text_Diff3_Op {
 
-    function Text_Diff3_Op($orig = false, $final1 = false, $final2 = false)
+    function __construct($orig = false, $final1 = false, $final2 = false)
     {
         $this->orig = $orig ? $orig : array();
         $this->final1 = $final1 ? $final1 : array();
@@ -194,7 +196,7 @@ class Text_Diff3_Op {
  */
 class Text_Diff3_Op_copy extends Text_Diff3_Op {
 
-    function Text_Diff3_Op_Copy($lines = false)
+    function __construct($lines = false)
     {
         $this->orig = $lines ? $lines : array();
         $this->final1 = &$this->orig;
@@ -221,7 +223,7 @@ class Text_Diff3_Op_copy extends Text_Diff3_Op {
  */
 class Text_Diff3_BlockBuilder {
 
-    function Text_Diff3_BlockBuilder()
+    function __construct()
     {
         $this->_init();
     }

--- a/includes/pear_diff/docs/examples/diff.php
+++ b/includes/pear_diff/docs/examples/diff.php
@@ -9,9 +9,20 @@
  * @package Text_Diff
  */
 
-require_once 'Text/Diff.php';
-require_once 'Text/Diff/Renderer.php';
-require_once 'Text/Diff/Renderer/unified.php';
+/** Text_Diff */
+if (!class_exists('Text_Diff')) {
+    require_once 'Text/Diff.php';
+}
+
+/** Text_Diff_Renderer */
+if (!class_exists('Text_Diff_Renderer')) {
+    require_once 'Text/Diff/Renderer.php';
+}
+
+/** Text_Diff_Renderer_unified */
+if (!class_exists('Text_Diff_Renderer_unified')) {
+    require_once 'Text/Diff/Renderer/unified.php';
+}
 
 /* Make sure we have enough arguments. */
 if (count($argv) < 3) {

--- a/includes/pear_diff/tests/diff_shell.phpt
+++ b/includes/pear_diff/tests/diff_shell.phpt
@@ -1,0 +1,62 @@
+--TEST--
+Text_Diff: Basic diff operation, shell engine
+--FILE--
+<?php
+include_once 'Text/Diff.php';
+
+$lines1 = file(dirname(__FILE__) . '/1.txt');
+$lines2 = file(dirname(__FILE__) . '/2.txt');
+
+$diff = new Text_Diff('shell', array($lines1, $lines2));
+echo strtolower(print_r($diff, true));
+?>
+--EXPECT--
+text_diff object
+(
+    [_edits] => array
+        (
+            [0] => text_diff_op_copy object
+                (
+                    [orig] => array
+                        (
+                            [0] => this line is the same.
+                        )
+
+                    [final] => array
+                        (
+                            [0] => this line is the same.
+                        )
+
+                )
+
+            [1] => text_diff_op_change object
+                (
+                    [orig] => array
+                        (
+                            [0] => this line is different in 1.txt
+                        )
+
+                    [final] => array
+                        (
+                            [0] => this line is different in 2.txt
+                        )
+
+                )
+
+            [2] => text_diff_op_copy object
+                (
+                    [orig] => array
+                        (
+                            [0] => this line is the same.
+                        )
+
+                    [final] => array
+                        (
+                            [0] => this line is the same.
+                        )
+
+                )
+
+        )
+
+)

--- a/includes/pear_diff/tests/pear_bug12740.phpt
+++ b/includes/pear_diff/tests/pear_bug12740.phpt
@@ -3,8 +3,8 @@ Text_Diff: PEAR Bug #12740 (failed assertion)
 --FILE--
 <?php
 
-require dirname(__FILE__) . '/../Diff.php';
-require dirname(__FILE__) . '/../Diff/Renderer/inline.php';
+require dirname(__FILE__) . '/../Text/Diff.php';
+require dirname(__FILE__) . '/../Text/Diff/Renderer/inline.php';
 
 $a = <<<QQ
 <li>The tax credit amounts to 30% of the cost of the system, with a

--- a/includes/pear_diff/tests/pear_bug4982.phpt
+++ b/includes/pear_diff/tests/pear_bug4982.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Text_Diff: PEAR Bug #4982 (wrong line breaks with inline renderer)
+--SKIPIF--
+<?php
+echo "skip Bug has been accepted but not fixed yet.";
+?>
+--FILE--
+<?php
+include_once 'Text/Diff.php';
+include_once 'Text/Diff/Renderer/inline.php';
+
+$oldtext = <<<EOT
+This line is different in 1.txt
+EOT;
+
+$newtext = <<<EOT
+This is new !!
+This line is different in 2.txt
+EOT;
+
+$oldpieces = explode("\n", $oldtext);
+$newpieces = explode("\n", $newtext);
+$diff = new Text_Diff('native', array($oldpieces, $newpieces));
+
+$renderer = new Text_Diff_Renderer_inline();
+echo $renderer->render($diff);
+?>
+--EXPECT--
+<ins>This is new !!</ins>
+This line is different in <del>1.txt</del><ins>2.txt</ins>

--- a/includes/pear_diff/tests/pear_bug7839.phpt
+++ b/includes/pear_diff/tests/pear_bug7839.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Text_Diff: PEAR Bug #7839 ()
+--FILE--
+<?php
+include_once 'Text/Diff.php';
+include_once 'Text/Diff/Renderer.php';
+
+$oldtext = <<<EOT
+This is line 1.
+This is line 2.
+This is line 3.
+This is line 4.
+This is line 5.
+This is line 6.
+This is line 7.
+This is line 8.
+This is line 9.
+EOT;
+
+$newtext = <<< EOT
+This is line 1.
+This was line 2.
+This is line 3.
+This is line 5.
+This was line 6.
+This was line 7.
+This was line 8.
+This is line 9.
+This is line 10.
+EOT;
+
+$oldpieces = explode ("\n", $oldtext);
+$newpieces = explode ("\n", $newtext);
+$diff = new Text_Diff('native', array($oldpieces, $newpieces));
+
+$renderer = new Text_Diff_Renderer();
+
+// We need to use var_dump, as the test runner strips trailing empty lines.
+echo($renderer->render($diff));
+?>
+--EXPECT--
+2c2
+< This is line 2.
+---
+> This was line 2.
+4d3
+< This is line 4.
+6,8c5,7
+< This is line 6.
+< This is line 7.
+< This is line 8.
+---
+> This was line 6.
+> This was line 7.
+> This was line 8.
+9a9
+> This is line 10.

--- a/includes/pear_diff/tests/unified2.patch
+++ b/includes/pear_diff/tests/unified2.patch
@@ -1,0 +1,3 @@
+@@ -1 +1 @@
+-For the first time in U.S. history number of private contractors and troops are equal
++Number of private contractors and troops are equal for first time in U.S. history

--- a/lib/Config.class.php
+++ b/lib/Config.class.php
@@ -19,7 +19,7 @@ class Config {
 	
 	public function getConfigModuleSQL($clear = true)
 	{
-		if ($clear) { $this->module_conf = ""; }
+		if ($clear) { $this->module_conf = array(); }
 		$sql = "SELECT var_name, value FROM endpointman_global_vars";
 		foreach (sql($sql, 'getAll', DB_FETCHMODE_ASSOC) as $row) {
 			$this->module_conf[$row['var_name']] = $row['value'];

--- a/page.epm_devices.php
+++ b/page.epm_devices.php
@@ -25,12 +25,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-// Check for safe mode
 
-
-if( ini_get('safe_mode') ){
-	die(_('Turn Off Safe Mode'));
-}
 if(file_exists('/tftpboot')) {
 	if(!is_writeable('/tftpboot')) {
 		die(_('/tftpboot is not writable'));


### PR DESCRIPTION
Removed safe_mode from page.epm_devices.php as it is deprecated and the if statement will never execute.

Fix gui_link_nw_tab constructor functions in functions.inc.php by hand so it will work on php71

Fix constructor functions in the pear_diff includes library by download a new version from pear website. (https://pear.php.net/package/Text_Diff)