### PR TITLE
Fix for PHP constructor name for PHP 7

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -282,7 +282,7 @@ function endpointman_configpageload() {
                 $currentcomponent->addguielem($section, new gui_checkbox('epm_delete', $checked, 'Delete', 'Delete this Extension from Endpoint Manager'), 9);
 // phone web interface link
 	class gui_link_nw_tab extends guitext {
-    function gui_link_nw_tab($elemname, $text, $url, $userlang = true) {
+    function __construct($elemname, $text, $url, $userlang = true) {
         $parent_class = get_parent_class($this);
         $this->html_text = "<a href=\"$url\" target=\"_blank\" id =\"$this->elemname\">$text</a>";
     }


### PR DESCRIPTION
Functions with class name no longer considered a constructor, see stack trace:

fwconsole reload --verbose
Whoops\Exception\ErrorException: Methods with the same name as their class will not be constructors in a future version of PHP; gui_link_nw_tab has a deprecated constructor in file /var/www/html/admin/modules/endpointman/functions.inc.php on line 284
Stack trace:
  1. Whoops\Exception\ErrorException->() /var/www/html/admin/modules/endpointman/functions.inc.php:284
  2. Whoops\Run->handleError() /var/www/html/admin/bootstrap.php:364
  3. require_once() /var/www/html/admin/bootstrap.php:364
  4. require_once() /etc/freepbx.conf:9
  5. include_once() /var/lib/asterisk/bin/fwconsole:12